### PR TITLE
Fix serial port access

### DIFF
--- a/io.github.wh201906.serialtest.yml
+++ b/io.github.wh201906.serialtest.yml
@@ -10,7 +10,7 @@ finish-args:
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland
-  - --device=dri
+  - --device=all
 modules:
   - name: qcustomplot
     buildsystem: qmake


### PR DESCRIPTION
This should fix https://github.com/wh201906/SerialTest/issues/19

According to these configs:  
https://github.com/flathub/uk.org.greenend.chiark.sgtatham.putty/blob/535c1993e609d6e6f8a2f941c4bfadd1c3ac2dbb/uk.org.greenend.chiark.sgtatham.putty.yml#L12   
https://github.com/flathub/com.gitlab.cutecom.cutecom/blob/8f8165aea7ad91bc3883bedbb7fb2dcf6a81de73/com.gitlab.cutecom.cutecom.json#L14   
https://github.com/flathub/org.gnome.moserial/blob/cb398d6d111fdcc78d60de4ff6789b0513095d24/org.gnome.moserial.yaml#L8   
https://github.com/flathub/art.taunoerik.tauno-serial-plotter/blob/2275b3741fcf77be5cae515c6e5d949432d9fdcd/art.taunoerik.tauno-serial-plotter.yml#L12